### PR TITLE
Fixed issue where history page wouldn't display image history if there were no CSVs uploaded

### DIFF
--- a/vite/src/components/historyTable.jsx
+++ b/vite/src/components/historyTable.jsx
@@ -149,10 +149,10 @@ const handleDownloadCSV = async (id) => {
     );
   }
 
-  if (data.length === 0) {
+  if (data.length === 0 && images.length === 0) {
     return (
       <div className="empty-state">
-        No files found. Upload a CSV file to get started.
+        No files or images found. Upload a CSV file or graph image to get started.
       </div>
     );
   }


### PR DESCRIPTION
Changed condition and messaging for history page empty state so that it will still display images if there are no CSVs